### PR TITLE
Update to gprolog v1.4.5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Buildpack that installs the current version (1.4.4 of this writing) on Cedar-14.
+Buildpack that installs the current version (1.4.5 of this writing) on Cedar-14.

--- a/bin/compile
+++ b/bin/compile
@@ -11,12 +11,12 @@ LP_DIR=`cd $(dirname $0); cd ..; pwd`
 
 TEMP_DIR=`mktemp -d "$BUILDPACK_DIR"/gprolog-XXXX`
 
-PROLOG_HOME=https://ftp.gnu.org/gnu/gprolog
-#PROLOG_HOME=http://gprolog.org
-PROLOG_VERSION=1.4.5
+GPROLOG_HOME=https://ftp.gnu.org/gnu/gprolog
+#GPROLOG_HOME=http://gprolog.org
+GPROLOG_VERSION=1.4.5
 
 echo "-----> Downloading"
-curl -sS $PROLOG_HOME/gprolog-$PROLOG_VERSION.tar.gz -o - | tar -zxf - -C $TEMP_DIR --strip 1
+curl -sS $GPROLOG_HOME/gprolog-$GPROLOG_VERSION.tar.gz -o - | tar -zxf - -C $TEMP_DIR --strip 1
 
 echo "-----> Configuring"
 cd $TEMP_DIR/src
@@ -30,11 +30,11 @@ make install
 echo "------> Writing profile script"
 mkdir -p $BUILD_DIR/.profile.d
 cat <<EOF >$BUILD_DIR/.profile.d/000_gprolog.sh
-export PATH="\$HOME/.gprolog/gprolog-\$PROLOG_VERSION/bin:\$PATH"
-export PL_PATH="\$HOME/.gprolog/gprolog-\$PROLOG_VERSION"
+export PATH="\$HOME/.gprolog/gprolog-\$GPROLOG_VERSION/bin:\$PATH"
+export PL_PATH="\$HOME/.gprolog/gprolog-\$GPROLOG_VERSION"
 EOF
 
-export PATH="$BUILD_DIR/.gprolog/gprolog-$PROLOG_VERSION/bin:$PATH"
-export PL_PATH="$BUILD_DIR/.gprolog/gprolog-$PROLOG_VERSION"
+export PATH="$BUILD_DIR/.gprolog/gprolog-$GPROLOG_VERSION/bin:$PATH"
+export PL_PATH="$BUILD_DIR/.gprolog/gprolog-$GPROLOG_VERSION"
 
 export | grep -E -e ' (PATH|PL_PATH)='  > "$LP_DIR/export"

--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,7 @@ LP_DIR=`cd $(dirname $0); cd ..; pwd`
 
 TEMP_DIR=`mktemp -d "$BUILDPACK_DIR"/gprolog-XXXX`
 
-PROLOG_HOME=https://ftp.gnu.org
+PROLOG_HOME=https://ftp.gnu.org/gnu/gprolog
 #PROLOG_HOME=http://gprolog.org
 PROLOG_VERSION=1.4.5
 

--- a/bin/compile
+++ b/bin/compile
@@ -11,8 +11,12 @@ LP_DIR=`cd $(dirname $0); cd ..; pwd`
 
 TEMP_DIR=`mktemp -d "$BUILDPACK_DIR"/gprolog-XXXX`
 
+PROLOG_HOME=https://ftp.gnu.org
+#PROLOG_HOME=http://gprolog.org
+PROLOG_VERSION=1.4.5
+
 echo "-----> Downloading"
-curl -sS https://ftp.gnu.org/gnu/gprolog/gprolog-1.4.4.tar.gz -o - | tar -zxf - -C $TEMP_DIR --strip 1
+curl -sS $PROLOG_HOME/gprolog-$PROLOG_VERSION.tar.gz -o - | tar -zxf - -C $TEMP_DIR --strip 1
 
 echo "-----> Configuring"
 cd $TEMP_DIR/src
@@ -26,11 +30,11 @@ make install
 echo "------> Writing profile script"
 mkdir -p $BUILD_DIR/.profile.d
 cat <<EOF >$BUILD_DIR/.profile.d/000_gprolog.sh
-export PATH="\$HOME/.gprolog/gprolog-1.4.4/bin:\$PATH"
-export PL_PATH="\$HOME/.gprolog/gprolog-1.4.4"
+export PATH="\$HOME/.gprolog/gprolog-\$PROLOG_VERSION/bin:\$PATH"
+export PL_PATH="\$HOME/.gprolog/gprolog-\$PROLOG_VERSION"
 EOF
 
-export PATH="$BUILD_DIR/.gprolog/gprolog-1.4.4/bin:$PATH"
-export PL_PATH="$BUILD_DIR/.gprolog/gprolog-1.4.4"
+export PATH="$BUILD_DIR/.gprolog/gprolog-$PROLOG_VERSION/bin:$PATH"
+export PL_PATH="$BUILD_DIR/.gprolog/gprolog-$PROLOG_VERSION"
 
 export | grep -E -e ' (PATH|PL_PATH)='  > "$LP_DIR/export"


### PR DESCRIPTION
Also provide backup home when ftp.gnu.org is down.

Changes are currently untested.